### PR TITLE
feat: implement fallback HTTP calls for missing recordings

### DIFF
--- a/__tests__/api-replay.test.ts
+++ b/__tests__/api-replay.test.ts
@@ -148,7 +148,7 @@ describe('api-replay', () => {
     expect(data2).toEqual(data1);
   });
 
-  test('throws error when no matching recording found', async () => {
+  test('makes actual HTTP call when no matching recording found', async () => {
     const testName = 'no-match-test';
 
     // First run - record a specific request
@@ -156,13 +156,14 @@ describe('api-replay', () => {
     await fetch('https://jsonplaceholder.typicode.com/posts/1');
     await replayAPI.done();
 
-    // Second run - try to replay a different request
+    // Second run - try to replay a different request (should make actual call)
     await replayAPI.start(testName);
+    const response = await fetch('https://jsonplaceholder.typicode.com/posts/2');
 
-    // Properly test async error throwing
-    await expect(async () => {
-      await fetch('https://jsonplaceholder.typicode.com/posts/2');
-    }).toThrow('No matching recorded call found');
+    // Should succeed by making actual HTTP call
+    expect(response.ok).toBe(true);
+    const data = await response.json();
+    expect(data.id).toBe(2);
 
     await replayAPI.done();
   });

--- a/__tests__/detailed-error-logging.test.ts
+++ b/__tests__/detailed-error-logging.test.ts
@@ -20,7 +20,7 @@ describe('Detailed Error Logging', () => {
     }
   });
 
-  test('should provide detailed search information when no match found', async () => {
+  test('should make actual HTTP call when no match found and record new call', async () => {
     // Create a recording with a specific request
     await replayAPI.start(testName, {
       debug: true,
@@ -31,7 +31,7 @@ describe('Detailed Error Logging', () => {
     });
 
     // Make a request that will be recorded
-    const response = await fetch('https://jsonplaceholder.typicode.com/posts/1?userId=1', {
+    const response1 = await fetch('https://jsonplaceholder.typicode.com/posts/1?userId=1', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -41,10 +41,10 @@ describe('Detailed Error Logging', () => {
       body: JSON.stringify({ title: 'Test Post', body: 'Test content' })
     });
 
-    await response.text(); // Consume the response
+    await response1.text(); // Consume the response
     await replayAPI.done();
 
-    // Now try to replay with a different request
+    // Now try to replay with a different request (should make actual call)
     await replayAPI.start(testName, {
       debug: true,
       recordFailedResponses: true,
@@ -53,57 +53,23 @@ describe('Detailed Error Logging', () => {
       }
     });
 
-    try {
-      // Make a request that doesn't match the recorded one
-      await fetch('https://jsonplaceholder.typicode.com/posts/2?userId=2', {
-        method: 'GET',
-        headers: {
-          Authorization: 'Bearer token456',
-          'X-Custom-Header': 'value2'
-        }
-      });
-
-      // This should not be reached
-      expect(true).toBe(false);
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-
-      // Verify the error contains detailed search information
-      expect(errorMessage).toContain(
-        'No matching recorded call found for: GET https://jsonplaceholder.typicode.com/posts/2?userId=2'
-      );
-      expect(errorMessage).toContain('Search details:');
-
-      // Parse the JSON search details
-      const searchDetailsMatch = errorMessage.match(/Search details:\n([\s\S]*)/);
-      expect(searchDetailsMatch).toBeTruthy();
-
-      if (searchDetailsMatch) {
-        const searchDetails = JSON.parse(searchDetailsMatch[1]);
-
-        // Verify the search details structure
-        expect(searchDetails.method).toBe('GET');
-        expect(searchDetails.url).toBe('https://jsonplaceholder.typicode.com/posts/2?userId=2');
-        expect(searchDetails.pathname).toBe('/posts/2');
-        expect(searchDetails.queryParams).toEqual({ userId: '2' });
-        expect(searchDetails.headers).toHaveProperty('authorization', 'Bearer token456');
-        expect(searchDetails.headers).toHaveProperty('x-custom-header', 'value2');
-        expect(searchDetails.body).toBeNull();
-
-        // Verify available recordings
-        expect(searchDetails.availableRecordings).toHaveLength(1);
-        const availableRecording = searchDetails.availableRecordings[0];
-        expect(availableRecording.method).toBe('POST');
-        expect(availableRecording.url).toBe('https://jsonplaceholder.typicode.com/posts/1?userId=1');
-        expect(availableRecording.pathname).toBe('/posts/1');
-        expect(availableRecording.queryParams).toEqual({ userId: '1' });
-        expect(availableRecording.headers).toHaveProperty('authorization', 'Bearer token123');
-        expect(availableRecording.headers).toHaveProperty('x-custom-header', 'value1');
-        expect(availableRecording.bodyLength).toBeGreaterThan(0);
+    // Make a request that doesn't match the recorded one - should make actual HTTP call
+    const response2 = await fetch('https://jsonplaceholder.typicode.com/posts/2?userId=2', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer token456',
+        'X-Custom-Header': 'value2'
       }
-    }
+    });
 
-    await replayAPI.done();
+    // Should succeed by making actual HTTP call
+    expect(response2.ok).toBe(true);
+    const data = await response2.json();
+    expect(data.id).toBe(2);
+
+    const result = await replayAPI.done();
+    expect(result.mode).toBe('replay');
+    // wasReplayed might be false if no matching calls were found and only actual calls were made
   });
 
   test('should show matching configuration in debug mode', async () => {

--- a/__tests__/failed-responses.test.ts
+++ b/__tests__/failed-responses.test.ts
@@ -194,13 +194,10 @@ describe('Failed Responses Configuration', () => {
     const response3 = await fetch('https://jsonplaceholder.typicode.com/posts/1');
     expect(response3.status).toBe(200);
 
-    // Should NOT be able to match the error response (filtered out)
-    try {
-      await fetch('https://jsonplaceholder.typicode.com/posts/999999');
-      expect(true).toBe(false); // Should not reach here
-    } catch (error) {
-      expect(error.message).toContain('No matching recorded call found');
-    }
+    // Should NOT be able to match the error response (filtered out), but will make actual call
+    const response4 = await fetch('https://jsonplaceholder.typicode.com/posts/999999');
+    // The actual call to a non-existent post should return 404
+    expect(response4.status).toBe(404);
 
     const result = await replayAPI.done();
     expect(result.mode).toBe('replay');

--- a/__tests__/matching-config.test.ts
+++ b/__tests__/matching-config.test.ts
@@ -101,11 +101,14 @@ describe('Matching Configuration Tests', () => {
     // Second run - try to replay with different included header
     await replayAPI.start(testName, config);
 
-    await expect(async () => {
-      await fetch('https://jsonplaceholder.typicode.com/posts/1', {
-        headers: { authorization: 'Bearer differenttoken' }
-      });
-    }).toThrow('No matching recorded call found');
+    // Should make actual HTTP call when headers don't match
+    const response = await fetch('https://jsonplaceholder.typicode.com/posts/1', {
+      headers: { authorization: 'Bearer differenttoken' }
+    });
+
+    expect(response.ok).toBe(true);
+    const data = await response.json();
+    expect(data.id).toBe(1);
 
     await replayAPI.done();
   });
@@ -152,9 +155,12 @@ describe('Matching Configuration Tests', () => {
     // Second run - try to replay with different non-excluded param
     await replayAPI.start(testName, config);
 
-    await expect(async () => {
-      await fetch('https://jsonplaceholder.typicode.com/posts/1?timestamp=999&userId=789');
-    }).toThrow('No matching recorded call found');
+    // Should make actual HTTP call when non-excluded query params differ
+    const response = await fetch('https://jsonplaceholder.typicode.com/posts/1?timestamp=999&userId=789');
+
+    expect(response.ok).toBe(true);
+    const data = await response.json();
+    expect(data.id).toBe(1);
 
     await replayAPI.done();
   });

--- a/__tests__/soap-body-matching.test.ts
+++ b/__tests__/soap-body-matching.test.ts
@@ -102,16 +102,19 @@ describe('SOAP/XML Body Matching', () => {
       </soap:Body>
     </soap:Envelope>`;
 
-    await expect(async () => {
-      await fetch(`${serverUrl}/soap/users`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'text/xml; charset=utf-8',
-          SOAPAction: 'GetUser'
-        },
-        body: differentSoapRequest
-      });
-    }).toThrow(/No matching recorded call found/);
+    // Should make actual HTTP call when no match found
+    const response = await fetch(`${serverUrl}/soap/users`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'text/xml; charset=utf-8',
+        SOAPAction: 'GetUser'
+      },
+      body: differentSoapRequest
+    });
+
+    expect(response.ok).toBe(true);
+    const responseBody = await response.text();
+    expect(responseBody).toContain('<Name>John Doe</Name>');
   });
 
   test('should ignore SOAP body when exclude.body is true', async () => {


### PR DESCRIPTION
Replace error-throwing behavior with graceful fallback to actual HTTP calls when no matching recorded call is found.

## Changes
- When no matching recorded call is found, make real HTTP request and record it
- Automatically save new recordings for future use
- Add debug logging for fallback behavior
- Update tests to expect successful responses instead of errors
- Improve user experience by eliminating "No matching recorded call found" errors

Resolves #6

🤖 Generated with [Claude Code](https://claude.ai/code)